### PR TITLE
fix: TokenStorageImpl - redundant code has deleted

### DIFF
--- a/amocrm_api_client/token_provider/impl/standard/token_storage/TokenStorageImpl.py
+++ b/amocrm_api_client/token_provider/impl/standard/token_storage/TokenStorageImpl.py
@@ -50,9 +50,6 @@ class TokenStorageImpl(ITokenStorage):
             await afp.write(encoded_str)
 
     async def _recover_data(self) -> Mapping[str, Any]:
-        if not os.path.exists(self.__backup_file_path):
-            return {}
-
         try:
             async with async_open(self.__backup_file_path, "r") as afp:
                 encoded_str = await afp.readline()


### PR DESCRIPTION
Проверка на существование файла в блоке if избыточна, т. к. FileNotFoundError уже обрабатывается в блоке try-except. 
На лишнюю проверку тратиться лишнее время.